### PR TITLE
Adding JetBrains Gradle Changelog plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,70 @@
+<!-- Keep a Changelog guide -> https://keepachangelog.com -->
+
+# IntelliJ Platform Plugin Template Changelog
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [2.3.0] - 2020-12-25
+
+### Added
+
+### Changed
+
+- Upgrading to 2020.3
+- Upgrading IntelliJ Gradle plugin to 0.6.5
+- Upgrading Java 11 - see <a href="https://blog.jetbrains.com/platform/2020/09/intellij-project-migrates-to-java-11/">
+  the JetBrains Platform blog post announcing the migration</a></li>### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.2.1] - 2020-04-11
+
+### Added
+
+- GitHub Workflow Action for IntelliJ Platform Plugin Verifier
+
+### Changed
+
+- Upgrade to 2020.1
+- Upgrading IntelliJ Gradle plugin to 0.4.16
+- Upgrading Gradle to 6.2
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.0.1] - 2018-07-10
+
+### Added
+
+- Initial Release! Currently provides a notification upon opening an IntelliJ project with the project name.
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,15 @@
+//import org.jetbrains.changelog.date
+
 plugins {
   id 'java'
   id 'org.jetbrains.intellij' version '0.6.5'
+  id 'org.jetbrains.changelog' version '0.6.2'
 }
 
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'org.jetbrains.intellij'
+apply plugin: 'org.jetbrains.changelog'
 
 group 'com.chriscarini.jetbrains'
 version '2.3.0'
@@ -34,6 +38,10 @@ intellij {
   plugins[]
   pluginName 'intellij-sample-notification'
 
+  patchPluginXml {
+    changeNotes({ changelog.getUnreleased().toHTML() })
+  }
+
   // TODO (https://youtrack.jetbrains.com/issue/IDEA-252693) - Disabled this task because it was failing. See my
   //      comment on the above YouTrack issue, and thread here: https://jetbrains-platform.slack.com/archives/C5U8BM1MK/p1604722479347300?thread_ts=1602338567.267100&cid=C5U8BM1MK
   // Note: This gradle task is only needed if `SearchableConfigurable` is used,
@@ -44,29 +52,21 @@ intellij {
   }
 }
 
+changelog {
+  version = "${project.version}"
+  path = "${project.projectDir}/CHANGELOG.md"
+//  header = { "[${project.version}] - ${date()}" }
+  header = { "[${project.version}] - ${new Date().format('yyyy-MM-dd')}" }
+  headerParserRegex = ~/\d+\.\d+\.\d+/
+  itemPrefix = "-"
+  keepUnreleasedSection = true
+  unreleasedTerm = "[Unreleased]"
+  groups = ["Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"]
+}
+
 //runIde {
 //    jbrVersion 'jbrex8u202b1483.21'
 //}
-
-patchPluginXml {
-  changeNotes """
-        <h4>[$version] - ${new Date().format('yyyy-MM-dd')}</h4>
-        <h5>Upgrade</h5>
-        <ol>
-        <li>Upgrading to 2020.3</li>
-        <li>Upgrading IntelliJ Gradle plugin to 0.6.5</li>
-        <li>Upgrading Java 11 - see <a href="https://blog.jetbrains.com/platform/2020/09/intellij-project-migrates-to-java-11/">the JetBrains Platform blog post announcing the migration</a></li>
-        </ol>
-        <h5>Added</h5>
-        <ol>
-        <li>N/A</li>
-        </ol>
-        <h5>Fixed</h5>
-        <ol>
-        <li>N/A</li>
-        </ol>
-        """
-}
 
 // The below will surface warnings as errors - I want
 // this in the project to allow us to catch deprecation


### PR DESCRIPTION
See: https://github.com/JetBrains/gradle-changelog-plugin

**NOTE:** This fails when trying to `import org.jetbrains.changelog.date`, so instead I am using `new Date().format('yyyy-MM-dd')` instead of `date()` as the plugin docs suggest. This is hopefully a short workaround while I figure out what is causing this to fail. I am using this PR to open an issue on the plugin project and hopefully figure out whats going on.