### PR TITLE
Upgrading IntelliJ from 2022.3.1 to 2022.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2022.3.1 to 2022.3.2
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'sample-notification'
 # SemVer format -> https://semver.org
-pluginVersion = 2.8.1
+pluginVersion = 2.8.2
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 2.8.1
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2022.3.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2022.3.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 
@@ -24,7 +24,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2022.3.1
+platformVersion = 2022.3.2
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2022.3.1 to 2022.3.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661430/IntelliJ-IDEA-2022.3.2-223.8617.56-build-Release-Notes

# What's New?
IntelliJ IDEA 2022.3.2 is now available! 
<ul> 
 <li>We've been working to fully eliminate screen flickering in full-screen mode on macOS Ventura. It no longer occurs in most instances, though some corner cases may remain. If you continue to experience this problem, please let us know in our issue tracker. [<a href="https://youtrack.jetbrains.com/issue/JBR-4959/macOS-Ventura-Screen-flickering-after-OS-update-when-IDE-is-full-screen">JBR-4959</a>]</li> 
 <li>The behavior of the <em>Settings Sync</em> plugin has been updated. Settings synchronization across different IDE products is now turned off by default and can be enabled via a checkbox in <em>Settings/Preferences | Settings Sync.</em> [<a href="https://youtrack.jetbrains.com/issue/IDEA-233535/Customize-config-sharing-between-IDEs">IDEA-233535</a>]</li> 
 <li>The toolbar icons in the <em>Remote Host</em> tool window are now displayed correctly in the new UI. [<a href="https://youtrack.jetbrains.com/issue/IDEA-299612/">IDEA-299612</a>]</li> 
 <li>When committing via modal dialog, the process no longer freezes when additional external formatters or code analysis plugins are enabled. [<a href="https://youtrack.jetbrains.com/issue/IDEA-307428/Commit-dialog-commit-freezes-on-pre-commit-checks-when-go-fmt-enabled">IDEA-307428</a>]</li> 
 <li><em>Search Everywhere</em> once again works as expected, providing all text search results. [<a href="https://youtrack.jetbrains.com/issue/IDEA-307142/Search-everywhere-text-search-doesnt-always-find-all-the-results">IDEA-307142</a>]</li> 
 <li>The <em>Incorrect formatting</em> inspection no longer causes the IDE to freeze. [<a href="https://youtrack.jetbrains.com/issue/IDEA-308487/Incorrect-formatting-inspection-causes-freezes">IDEA-308487</a>]</li> 
 <li>The Kotlin plugin has been updated to version 1.8. [<a href="https://youtrack.jetbrains.com/issue/KTIJ-24378">KTIJ-24378</a>] </li> 
</ul> For more details, please see this 
<a href="https://blog.jetbrains.com/idea/2023/01/intellij-idea-2022-3-2/">blog post</a>.
    