### PR TITLE
Upgrading IntelliJ from 2023.2.4 to 2023.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.2.4 to 2023.2.5
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'sample-notification'
 # SemVer format -> https://semver.org
-pluginVersion = 3.1.4
+pluginVersion = 3.1.5
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 3.1.4
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.2.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2023.2.5,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 
@@ -24,7 +24,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.2.4
+platformVersion = 2023.2.5
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.2.4 to 2023.2.5

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661744/IntelliJ-IDEA-2023.2.5-232.10227.8-build-Release-Notes

# What's New?
IntelliJ IDEA 2023.2.5 is out with the following improvement: 
<ul> 
 <li>The IDE no longer encounters startup failures accompanied by the <em>"Cannot connect to an already running IDE instance"</em> error, which was previously triggered by an improper termination of the previous session. [<a href="https://youtrack.jetbrains.com/issue/IDEA-330531/">IDEA-330531</a>]</li> 
</ul> For more details, please refer to this 
<a href="https://blog.jetbrains.com/idea/2023/11/intellij-idea-2023-2-5">blog post</a>.
    