### PR TITLE
Upgrading IntelliJ from 2023.3.6 to 2024.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.3.6 to 2024.1.0
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,16 +4,16 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'sample-notification'
 # SemVer format -> https://semver.org
-pluginVersion = 3.2.6
+pluginVersion = 4.0.0
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 233
-pluginUntilBuild = 233.*
+pluginSinceBuild = 241
+pluginUntilBuild = 241.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.3.6,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 
@@ -23,7 +23,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.3.6
+platformVersion = 2024.1
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.3.6 to 2024.1.0

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661899/IntelliJ-IDEA-2024.1-241.14494.240-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.1 is now available with the following new features: 
<ul> 
 <li>Full line code completion</li> 
 <li>Java 22 support</li> 
 <li>New terminal (Beta)</li> 
 <li>Sticky lines in the editor</li> 
</ul> Visit our 
<a href="https://www.jetbrains.com/idea/whatsnew/">What's New page</a> or watch 
<a href="https://youtu.be/FuvoOm4TIxE">this video</a> to learn about these and other improvements.
    