### PR TITLE
Upgrading IntelliJ from 2025.1.1 to 2025.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2025.1.1 to 2025.1.2
 - Upgrading IntelliJ from 2025.1 to 2025.1.1
 - Migrate from `StartupActivity` (obsolete) -> `ProjectActivity`
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/intellij-notification-sampl
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 5.0.0
+pluginVersion = 5.0.1
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 251.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2025.1.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2025.1.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -33,7 +33,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2025.1.1
+platformVersion = 2025.1.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.1.1 to 2025.1.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662452/IntelliJ-IDEA-2025.1.2-251.26094.121-build-Release-Notes

# What's New?
<p>IntelliJ IDEA 2025.1.2 is out with the following improvements:</p>
<ul>
 <li>The IDE no longer fails to start if a plugin defines an action with unresolved message bundle keys, and it now provides a report identifying the problematic plugin. [<a href="https://youtrack.jetbrains.com/issue/IJPL-185981">IJPL-185981</a>]</li>
 <li>The IDE no longer produces the false positive <em>"Package is declared in module which is not in the module graph"</em> warning. [<a href="https://youtrack.jetbrains.com/issue/IDEA-371051">IDEA-371051</a>]</li>
 <li>The IDE once again correctly takes compilerArgs from <em>pom.xml </em>into account when building Maven projects. [<a href="https://youtrack.jetbrains.com/issue/IDEA-371747">IDEA-371747</a>]</li>
 <li>Font size rescaling for the Quick Documentation popup works as expected. [<a href="https://youtrack.jetbrains.com/issue/IJPL-184559/Cannot-adjust-font-size-of-quick-documentation-pop-up-windows">IJPL-184559</a>]</li>
 <li>Inspections in Terraform can now be suppressed again. [<a href="https://youtrack.jetbrains.com/issue/IJPL-149116/Suppress-inspection-dont-work-in-TerraForm-file">IJPL-149116</a>]<br></li>
</ul>
<p>Get more details from our <a href="https://blog.jetbrains.com/idea/2025/06/intellij-idea-2025-1-2/">blog post</a>.</p>
    